### PR TITLE
Add preclinical-to-clinical PK/PD workflow slide

### DIFF
--- a/_posts/0000-01-02-pkpd-workflow.md
+++ b/_posts/0000-01-02-pkpd-workflow.md
@@ -1,0 +1,30 @@
+---
+layout: slide
+title: "Preclinical → Clinical PK/PD Translation Workflow"
+---
+
+### Goal
+Ingest **preclinical PK** for a molecule, enrich with **target antigen properties**, and predict **PD endpoints** against observed **clinical PK/PD**.
+
+---
+
+### Data to ingest
+- Molecule attributes: modality, valency, Fc engineering, binding affinity.
+- Preclinical PK: species, dose route, concentration-time profiles, NCA/compartmental parameters.
+- Target antigen: baseline expression, turnover/internalization rate, soluble shed antigen, tissue distribution.
+- Clinical readouts: PK profiles, biomarker/PD endpoints, receptor occupancy.
+
+---
+
+### Modeling approach
+1. Build a **mechanistic PK/PD model** (TMDD or minimal PBPK + effect model).
+2. Calibrate on preclinical data and antigen biology priors.
+3. Apply allometric or physiology-based scaling into human.
+4. Simulate clinical scenarios and compare predicted vs observed PK/PD metrics.
+
+---
+
+### Comparison outputs
+- PK: Cmax, AUC, CL, Vd, t1/2.
+- PD: Emax, EC50/IC50, time above threshold, target occupancy.
+- Goodness-of-fit: prediction error, visual predictive checks, posterior predictive intervals.


### PR DESCRIPTION
### Motivation
- Provide a concise slide that documents a reproducible workflow to ingest preclinical PK for a molecule, enrich it with target antigen properties, and predict PD endpoints for direct comparison to clinical PK/PD readouts.

### Description
- Added a new slideshow post at `_posts/0000-01-02-pkpd-workflow.md` (layout: `slide`) containing sections for Goal, Data to ingest, Modeling approach (TMDD/minimal PBPK + effect model), and Comparison outputs (PK/PD metrics and goodness-of-fit).

### Testing
- Ran `git status --short` which showed the new file, attempted `script/server` to preview but the `jekyll` executable was unavailable, and `bundle install` failed with HTTP 403 from `rubygems.org`, so a local build/preview could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698516a0a7848327831c9c5dedcc6871)